### PR TITLE
Flat token format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,4 +19,4 @@ pub use claims::{Claims, RegisteredClaims};
 pub use fmt::JWTFormat;
 pub use jose::{Header, RegisteredHeader};
 pub use token::Token;
-pub use token::{Compact, Flat};
+pub use token::{Compact, Flat, FlatUnprotected};

--- a/src/token/formats.rs
+++ b/src/token/formats.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use serde::{Deserialize, Serialize};
+use serde::{ser, Deserialize, Serialize};
 
 use super::{HasSignature, MaybeSigned};
 use super::{Payload, Token};
@@ -20,13 +20,14 @@ impl Compact {
     }
 }
 
-/// A token format that serializes the token as a single JSON object.
+/// A token format that serializes the token as a single JSON object,
+/// with the unprotected header as a top-level field.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Flat<U> {
+pub struct FlatUnprotected<U> {
     unprotected: U,
 }
 
-impl<U> Flat<U> {
+impl<U> FlatUnprotected<U> {
     /// Creates a new `Flat` token format with the given unprotected header.
     pub fn new(unprotected: U) -> Self {
         Self { unprotected }
@@ -42,6 +43,10 @@ impl<U> Flat<U> {
         &mut self.unprotected
     }
 }
+
+/// A token format that serializes the token as a single JSON object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Flat;
 
 /// Error returned when a token cannot be formatted as a string.
 ///
@@ -103,7 +108,7 @@ struct FlatToken<'t, P, U> {
     signature: String,
 }
 
-impl<U> TokenFormat for Flat<U>
+impl<U> TokenFormat for FlatUnprotected<U>
 where
     U: Serialize,
 {
@@ -132,5 +137,98 @@ where
         write!(writer, "{}", data)?;
 
         Ok(())
+    }
+}
+
+impl<P, S, U> Serialize for Token<P, S, FlatUnprotected<U>>
+where
+    S: HasSignature,
+    <S as MaybeSigned>::Header: Serialize,
+    <S as MaybeSigned>::HeaderState: Serialize,
+    U: Serialize,
+    P: Serialize,
+{
+    fn serialize<Ser>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error>
+    where
+        Ser: ser::Serializer,
+    {
+        let header = Base64JSON(self.state.header())
+            .serialized_value()
+            .map_err(|err| ser::Error::custom(err))?;
+        let signature = Base64Data(self.state.signature())
+            .serialized_value()
+            .map_err(|err| ser::Error::custom(err))?;
+
+        let flat = FlatToken {
+            payload: &self.payload,
+            protected: header,
+            unprotected: &self.fmt.unprotected,
+            signature,
+        };
+
+        flat.serialize(serializer)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct FlatSimpleToken<'t, P> {
+    payload: &'t Payload<P>,
+    protected: String,
+    signature: String,
+}
+
+impl TokenFormat for Flat {
+    fn render<S>(
+        &self,
+        writer: &mut impl Write,
+        token: &Token<impl Serialize, S, Self>,
+    ) -> Result<(), TokenFormattingError>
+    where
+        Self: Sized,
+        S: HasSignature,
+        <S as MaybeSigned>::Header: Serialize,
+        <S as MaybeSigned>::HeaderState: Serialize,
+    {
+        let header = Base64JSON(&token.state.header()).serialized_value()?;
+        let signature = Base64Data(token.state.signature()).serialized_value()?;
+
+        let flat = FlatSimpleToken {
+            payload: &token.payload,
+            protected: header,
+            signature,
+        };
+
+        let data = serde_json::to_string(&flat)?;
+        write!(writer, "{}", data)?;
+
+        Ok(())
+    }
+}
+
+impl<P, S> Serialize for Token<P, S, Flat>
+where
+    S: HasSignature,
+    <S as MaybeSigned>::Header: Serialize,
+    <S as MaybeSigned>::HeaderState: Serialize,
+    P: Serialize,
+{
+    fn serialize<Ser>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error>
+    where
+        Ser: ser::Serializer,
+    {
+        let header = Base64JSON(self.state.header())
+            .serialized_value()
+            .map_err(|err| ser::Error::custom(err))?;
+        let signature = Base64Data(self.state.signature())
+            .serialized_value()
+            .map_err(|err| ser::Error::custom(err))?;
+
+        let flat = FlatSimpleToken {
+            payload: &self.payload,
+            protected: header,
+            signature,
+        };
+
+        flat.serialize(serializer)
     }
 }

--- a/src/token/formats.rs
+++ b/src/token/formats.rs
@@ -154,10 +154,10 @@ where
     {
         let header = Base64JSON(self.state.header())
             .serialized_value()
-            .map_err(|err| ser::Error::custom(err))?;
+            .map_err(ser::Error::custom)?;
         let signature = Base64Data(self.state.signature())
             .serialized_value()
-            .map_err(|err| ser::Error::custom(err))?;
+            .map_err(ser::Error::custom)?;
 
         let flat = FlatToken {
             payload: &self.payload,
@@ -218,10 +218,10 @@ where
     {
         let header = Base64JSON(self.state.header())
             .serialized_value()
-            .map_err(|err| ser::Error::custom(err))?;
+            .map_err(ser::Error::custom)?;
         let signature = Base64Data(self.state.signature())
             .serialized_value()
-            .map_err(|err| ser::Error::custom(err))?;
+            .map_err(ser::Error::custom)?;
 
         let flat = FlatSimpleToken {
             payload: &self.payload,

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -26,7 +26,7 @@ use crate::{
 mod formats;
 mod state;
 
-pub use self::formats::{Compact, Flat, TokenFormat, TokenFormattingError};
+pub use self::formats::{Compact, Flat, FlatUnprotected, TokenFormat, TokenFormattingError};
 pub use self::state::{HasSignature, MaybeSigned, Signed, Unsigned, Unverified, Verified};
 
 /// A JWT Playload. Most payloads are JSON objects, which are serialized, and then converted
@@ -223,10 +223,7 @@ impl<P, H> Token<P, Unsigned<H>, Compact> {
     }
 }
 
-impl<P, U, H> Token<P, Unsigned<H>, Flat<U>>
-where
-    U: Serialize,
-{
+impl<P, H> Token<P, Unsigned<H>, Flat> {
     /// Create a new token with the given header and payload, in the flat format.
     ///
     /// See also [`Token::new`] and [`Token::compact`] to create a token in a specific format.
@@ -234,8 +231,8 @@ where
     /// The flat format is the format with a JSON object containing the header, payload, and
     /// signature, all in the same object. It can also include additional JSON data as "unprotected"\
     /// headers, which are not signed and cannot be verified.
-    pub fn flat(header: H, unprotected: U, payload: P) -> Token<P, Unsigned<H>, Flat<U>> {
-        Token::new(header, payload, Flat::new(unprotected))
+    pub fn flat(header: H, payload: P) -> Token<P, Unsigned<H>, Flat> {
+        Token::new(header, payload, Flat)
     }
 }
 


### PR DESCRIPTION
- Bug: JWK must render all keys in alphabetical order
- Feature: New Flat format which omits unprotected headers
