### PR TITLE
Signature-traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde = { version = "1.0.160", features = ["derive"] }
 serde_json = "1.0.96"
 sha1 = "0.10.5"
 sha2 = "0.10.6"
-signature = "2.1.0"
+signature = { version = "2.1.0", features = ["std", "digest"] }
 thiserror = "1.0.40"
 url = { version = "2.3.1", features = ["serde"] }
 zeroize = { version = "1.6.0", features = ["std", "serde", "derive"] }
@@ -53,7 +53,7 @@ p521 = { version = "0.13.0", optional = true }
 hmac = { version = "0.12.1", features = ["reset"], optional = true }
 
 [features]
-default = ["fmt", "rsa", "ecdsa", "p256", "p384", "p521", "hmac"]
+default = ["fmt", "rsa", "ecdsa", "p256", "p384", "p521"]
 fmt = []
 rsa = ["dep:rsa"]
 hmac = ["dep:hmac"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ p521 = { version = "0.13.0", optional = true }
 hmac = { version = "0.12.1", features = ["reset"], optional = true }
 
 [features]
-default = ["fmt", "rsa", "ecdsa", "p256", "p384", "p521"]
+default = ["fmt", "rsa", "ecdsa", "p256", "p384", "p521", "hmac"]
 fmt = []
 rsa = ["dep:rsa"]
 hmac = ["dep:hmac"]

--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ use jaws::JWTFormat;
 // signing and verification status.
 use jaws::Token;
 
-use jaws::algorithms::rsa::RsaPkcs1v15Verify;
 // The unverified token state, used like `Token<.., Unverified<..>, ..>`.
 // It is generic over the type of the custom header parameters.
 use jaws::token::Unverified;
@@ -103,10 +102,6 @@ use rsa::pkcs8::DecodePrivateKey;
 // The signing algorithm we will use (`RS256`) relies on the SHA-256 hash
 // function, so we get it here from the `sha2` crate in the RustCrypto suite.
 use sha2::Sha256;
-
-// This is an alias for the RSA PKCS#1 v1.5 signing algorithm, which is
-// implemented in the rsa crate as `rsa::pkcs1v15::SigningKey`.
-use jaws::algorithms::rsa::RsaPkcs1v15;
 
 // Using serde_json allows us to quickly construct a serializable payload,
 // but applications may want to instead define a struct and use serde to
@@ -127,7 +122,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // RsaPkcs1v15 is really an alias to the digital signature algorithm
     // implementation in the `rsa` crate, but provided in JAWS to make
     // it clear which types are compatible with JWTs.
-    let alg = RsaPkcs1v15::<Sha256>::new_with_prefix(key);
+    let alg = rsa::pkcs1v15::SigningKey::<Sha256>::new_with_prefix(key);
 
     // Claims can combine registered and custom fields. The claims object
     // can be any type which implements [serde::Serialize].
@@ -196,7 +191,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(&key, alg.as_ref().deref());
 
-    let alg: RsaPkcs1v15Verify<Sha256> = RsaPkcs1v15Verify::new_with_prefix(key);
+    let alg: rsa::pkcs1v15::VerifyingKey<Sha256> =
+        rsa::pkcs1v15::VerifyingKey::new_with_prefix(key);
 
     // We can't access the claims until we verify the token.
     let verified = token.verify(&alg).unwrap();

--- a/examples/acme-new-account.rs
+++ b/examples/acme-new-account.rs
@@ -1,4 +1,3 @@
-use jaws::algorithms::rsa::RsaPkcs1v15;
 use jaws::Compact;
 use jaws::JWTFormat;
 use jaws::Token;
@@ -48,7 +47,7 @@ fn main() {
     // RsaPkcs1v15 is really an alias to the digital signature algorithm
     // implementation in the `rsa` crate, but provided in JAWS to make
     // it clear which types are compatible with JWTs.
-    let alg = RsaPkcs1v15::<Sha256>::new_with_prefix(key);
+    let alg = rsa::pkcs1v15::SigningKey::<Sha256>::new_with_prefix(key);
 
     let payload = json!({
       "termsOfServiceAgreed": true,

--- a/examples/rfc7515a2.rs
+++ b/examples/rfc7515a2.rs
@@ -10,7 +10,6 @@ use jaws::JWTFormat;
 // signing and verification status.
 use jaws::Token;
 
-use jaws::algorithms::rsa::RsaPkcs1v15Verify;
 // The unverified token state, used like `Token<.., Unverified<..>, ..>`.
 // It is generic over the type of the custom header parameters.
 use jaws::token::Unverified;
@@ -25,10 +24,6 @@ use rsa::pkcs8::DecodePrivateKey;
 // The signing algorithm we will use (`RS256`) relies on the SHA-256 hash
 // function, so we get it here from the `sha2` crate in the RustCrypto suite.
 use sha2::Sha256;
-
-// This is an alias for the RSA PKCS#1 v1.5 signing algorithm, which is
-// implemented in the rsa crate as `rsa::pkcs1v15::SigningKey`.
-use jaws::algorithms::rsa::RsaPkcs1v15;
 
 // Using serde_json allows us to quickly construct a serializable payload,
 // but applications may want to instead define a struct and use serde to
@@ -49,7 +44,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // RsaPkcs1v15 is really an alias to the digital signature algorithm
     // implementation in the `rsa` crate, but provided in JAWS to make
     // it clear which types are compatible with JWTs.
-    let alg = RsaPkcs1v15::<Sha256>::new_with_prefix(key);
+    let alg = rsa::pkcs1v15::SigningKey::<Sha256>::new_with_prefix(key);
 
     // Claims can combine registered and custom fields. The claims object
     // can be any type which implements [serde::Serialize].
@@ -118,7 +113,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(&key, alg.as_ref().deref());
 
-    let alg: RsaPkcs1v15Verify<Sha256> = RsaPkcs1v15Verify::new_with_prefix(key);
+    let alg: rsa::pkcs1v15::VerifyingKey<Sha256> =
+        rsa::pkcs1v15::VerifyingKey::new_with_prefix(key);
 
     // We can't access the claims until we verify the token.
     let verified = token.verify(&alg).unwrap();

--- a/justfile
+++ b/justfile
@@ -4,6 +4,10 @@ test:
     @echo "Running tests..."
     cargo hack test --feature-powerset --group-features ecdsa,p256,p384,p521
 
+check:
+    @echo "Checking..."
+    cargo hack check --feature-powerset --group-features ecdsa,p256,p384,p521
+
 doc:
     @echo "Building docs..."
     cargo doc --all-features

--- a/src/algorithms/ecdsa.rs
+++ b/src/algorithms/ecdsa.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides implementations of the ECDSA signing algorithms for use with JSON Web Tokens.
 //!
-//! It uses [elliptic_curve::SecretKey] as the base type, and provides implementations of the ECDSA
+//! It uses [ecdsa::SigningKey] and [ecdsa::VerifyingKey] as the key types, and provides implementations of the ECDSA
 //! signing algorithms for the following curves:
 //! - P-256 (ES256)
 //! - P-384 (ES384)
@@ -66,7 +66,8 @@ println!("{}", signed.formatted());
 "#
 )]
 
-use ::ecdsa::{hazmat::SignPrimitive, PrimeCurve, SignatureSize, SigningKey, VerifyingKey};
+use ::ecdsa::{hazmat::SignPrimitive, PrimeCurve, SignatureSize};
+pub use ::ecdsa::{SigningKey, VerifyingKey};
 use base64ct::Encoding;
 use digest::generic_array::ArrayLength;
 use elliptic_curve::{
@@ -88,10 +89,6 @@ pub use p521::NistP521;
 impl<C> crate::key::JWKeyType for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic + JwkParameters,
-    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldBytesSize<C>: ModulusSize,
 {
     const KEY_TYPE: &'static str = "EC";
 }
@@ -99,8 +96,6 @@ where
 impl<C> crate::key::SerializeJWK for VerifyingKey<C>
 where
     C: PrimeCurve + CurveArithmetic + JwkParameters,
-    Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
-    SignatureSize<C>: ArrayLength<u8>,
     AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
     FieldBytesSize<C>: ModulusSize,
 {
@@ -146,8 +141,6 @@ where
     C: PrimeCurve + CurveArithmetic + JwkParameters,
     Scalar<C>: Invert<Output = CtOption<Scalar<C>>> + SignPrimitive<C>,
     SignatureSize<C>: ArrayLength<u8>,
-    AffinePoint<C>: FromEncodedPoint<C> + ToEncodedPoint<C>,
-    FieldBytesSize<C>: ModulusSize,
 {
     const KEY_TYPE: &'static str = "EC";
 }

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -6,9 +6,10 @@
 //!
 //! [RFC7518]: https://tools.ietf.org/html/rfc7518
 
+use bytes::Bytes;
+use digest::Digest;
 use serde::{Deserialize, Serialize};
-
-use crate::key;
+use signature::SignatureEncoding;
 
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;
@@ -88,59 +89,104 @@ impl AlgorithmIdentifier {
 ///
 /// Algorithm identifiers are used in JWS and JWE to indicate how a token is signed or encrypted.
 /// They are set in the [crate::jose::Header] automatically when signing the JWT.
-pub trait Algorithm {
+pub trait JoseAlgorithm {
     /// The identifier for this algorithm when used in a JWT registered header.
     ///
     /// This is the `alg` field in the JOSE header.
     const IDENTIFIER: AlgorithmIdentifier;
 
-    /// The type of the signature, which should be representable as bytes.
-    type Signature: AsRef<[u8]>;
+    /// The type of the signature, which must support encoding.
+    type Signature: SignatureEncoding;
+}
+
+/// A trait to associate an algorithm with a digest for signing.
+pub trait JoseDigestAlgorithm: JoseAlgorithm {
+    /// The digest algorithm used by this signature.
+    type Digest: Digest;
 }
 
 /// A trait to represent an algorithm which can sign a JWT.
 ///
 /// This trait should apply to signing keys.
-pub trait SigningAlgorithm: Algorithm {
-    /// Error type returned when signing fails.
-    type Error;
-
-    /// The inner key type (e.g. [::rsa::RsaPrivateKey]) used to complete the registered
-    /// header values.
-    type Key: key::SerializeJWK;
+pub trait TokenSigner: JoseAlgorithm {
+    /// Sign the contents of the JWT, when provided with the base64url-encoded header
+    /// and payload. This is the JWS Signature value, and will be base64url-encoded
+    /// and appended to the compact representation of the JWT.
+    fn try_sign_token(
+        &self,
+        header: &str,
+        payload: &str,
+    ) -> Result<Self::Signature, signature::Error>;
 
     /// Sign the contents of the JWT, when provided with the base64url-encoded header
     /// and payload. This is the JWS Signature value, and will be base64url-encoded
     /// and appended to the compact representation of the JWT.
-    fn sign(&self, header: &str, payload: &str) -> Result<Self::Signature, Self::Error>;
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the signature cannot be computed.
+    fn sign_token(&self, header: &str, payload: &str) -> Self::Signature {
+        self.try_sign_token(header, payload).unwrap()
+    }
+}
 
-    /// Return a reference to the key used to sign the JWT.
-    fn key(&self) -> &Self::Key;
+impl<K> TokenSigner for K
+where
+    K: JoseDigestAlgorithm,
+    K: signature::DigestSigner<K::Digest, K::Signature>,
+{
+    fn try_sign_token(
+        &self,
+        header: &str,
+        payload: &str,
+    ) -> Result<Self::Signature, signature::Error> {
+        let message = format!("{}.{}", header, payload);
+
+        let mut digest = <Self as JoseDigestAlgorithm>::Digest::new();
+        digest.update(message.as_bytes());
+
+        self.try_sign_digest(digest)
+    }
 }
 
 /// A trait to represent an algorithm which can verify a JWT.
 ///
 /// This trait should apply to the equivalent of public keys, which have enough information
 /// to verify a JWT signature, but not necessarily to sing it.
-pub trait VerifyAlgorithm: Algorithm {
-    /// Error type returned when verification fails.
-    type Error;
-
-    /// The inner key type (e.g. [::rsa::RsaPublicKey]) used to complete the registered
-    /// header values.
-    type Key: key::SerializeJWK;
-
+pub trait TokenVerifier: JoseAlgorithm {
     /// Verify the signature of the JWT, when provided with the base64url-encoded header
     /// and payload.
-    fn verify(
+    fn verify_token(
         &self,
         header: &[u8],
         payload: &[u8],
         signature: &[u8],
-    ) -> Result<Self::Signature, Self::Error>;
+    ) -> Result<Self::Signature, signature::Error>;
+}
 
-    /// Return a reference to the key used to verify the JWT.
-    fn key(&self) -> &Self::Key;
+impl<K> TokenVerifier for K
+where
+    K: JoseDigestAlgorithm,
+    K: signature::DigestVerifier<K::Digest, K::Signature>,
+{
+    fn verify_token(
+        &self,
+        header: &[u8],
+        payload: &[u8],
+        signature: &[u8],
+    ) -> Result<Self::Signature, signature::Error> {
+        let mut digest = <Self as JoseDigestAlgorithm>::Digest::new();
+        digest.update(header);
+        digest.update(b".");
+        digest.update(payload);
+
+        let signature = signature
+            .try_into()
+            .map_err(|_| signature::Error::default())?;
+
+        self.verify_digest(digest, &signature)?;
+        Ok(signature)
+    }
 }
 
 /// A signature which has not been matched to an algorithm or key.
@@ -148,20 +194,8 @@ pub trait VerifyAlgorithm: Algorithm {
 /// This is a basic signature `struct` which can be used to store any signature
 /// on the heap. It is used to store the signature of a JWT before it is verified,
 /// or if a signature has a variable length.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
-pub struct SignatureBytes(Vec<u8>);
-
-impl SignatureBytes {
-    /// Add to this signature from a byte slice.
-    pub fn extend_from_slice(&mut self, other: &[u8]) {
-        self.0.extend_from_slice(other);
-    }
-
-    /// Create a new signature with the given capacity.
-    pub fn with_capacity(capacity: usize) -> Self {
-        SignatureBytes(Vec::with_capacity(capacity))
-    }
-}
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SignatureBytes(Bytes);
 
 impl AsRef<[u8]> for SignatureBytes {
     fn as_ref(&self) -> &[u8] {
@@ -171,12 +205,28 @@ impl AsRef<[u8]> for SignatureBytes {
 
 impl From<&[u8]> for SignatureBytes {
     fn from(bytes: &[u8]) -> Self {
-        SignatureBytes(bytes.to_vec())
+        SignatureBytes(bytes.to_owned().into())
+    }
+}
+
+impl From<Bytes> for SignatureBytes {
+    fn from(bytes: Bytes) -> Self {
+        SignatureBytes(bytes)
+    }
+}
+
+impl From<SignatureBytes> for Bytes {
+    fn from(bytes: SignatureBytes) -> Self {
+        bytes.0.clone()
     }
 }
 
 impl From<Vec<u8>> for SignatureBytes {
     fn from(bytes: Vec<u8>) -> Self {
-        SignatureBytes(bytes)
+        SignatureBytes(bytes.into())
     }
+}
+
+impl signature::SignatureEncoding for SignatureBytes {
+    type Repr = Bytes;
 }

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -4,12 +4,66 @@
 //!
 //! See the submodules for specific algorithm implementations for signing.
 //!
+//! # Algorithm Traits
+//!
+//! JOSE uses a few traits to define appropriate signing algorithms. [`JoseAlgorithm`] is the main trait,
+//! which defines the algorithm identifier and the type of the signature. [`JoseDigestAlgorithm`] is a
+//! subtrait which defines the digest algorithm used by the signature, for algorithms which use digest
+//! signing (e.g. RSA-PSS, RSA-PKCS1-v1_5, ECDSA), and where a specific digest is specified by the algorithm
+//! identifier.
+//!
+//! [`TokenSigner`] and [`TokenVerifier`] are traits which define the ability to sign and verify a JWT.
+//! They are implemented for any [`JoseDigestAlgorithm`] which is also a [`DigestSigner`][signature::DigestSigner] or [`DigestVerifier`][signature::DigestVerifier].
+//!
+//! # Supported Algorithms
+//!
+//! ## HMAC
+//!
+//! - HS256: HMAC using SHA-256
+//! - HS384: HMAC using SHA-384
+//! - HS512: HMAC using SHA-512
+//!
+//! ## RSA
+//!
+//! - RS256: RSASSA-PKCS1-v1_5 using SHA-256
+//! - RS384: RSASSA-PKCS1-v1_5 using SHA-384
+//! - RS512: RSASSA-PKCS1-v1_5 using SHA-512
+//! - PS256: RSASSA-PSS using SHA-256 and MGF1 with SHA-256
+//! - PS384: RSASSA-PSS using SHA-384 and MGF1 with SHA-384
+//!
+//! ## ECDSA
+//!
+//! - ES256: ECDSA using P-256 and SHA-256
+//! - ES384: ECDSA using P-384 and SHA-384
+//!
+//! # Unsupported algorithms
+//!
+//! This crate does not support signing or verification with the `none` algorithm,
+//! as it is generally a security vulnerability.
+//!
+//! Currently, there is no support for the following algorithms:
+//!
+//! - EdDSA: EdDSA using Ed25519 is not yet supported.
+//! - ES512: ECDSA using P-521 and SHA-512 is not yet supported.
+//!
+//! All of these algorithms could be supported by providing suitable implementations
+//! of the [`JoseAlgorithm`] trait and the [`TokenSigner`] and [`TokenVerifier`] traits.
+//!
 //! [RFC7518]: https://tools.ietf.org/html/rfc7518
 
 use bytes::Bytes;
 use digest::Digest;
 use serde::{Deserialize, Serialize};
 use signature::SignatureEncoding;
+
+#[cfg(any(feature = "p256", feature = "hmac", feature = "rsa"))]
+pub use sha2::Sha256;
+
+#[cfg(any(feature = "p348", feature = "hmac", feature = "rsa"))]
+pub use sha2::Sha384;
+
+#[cfg(any(feature = "hmac", feature = "rsa"))]
+pub use sha2::Sha512;
 
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa;

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -2,8 +2,7 @@
 //!
 //! # PKCS#1 v1.5 (RS256, RS384, RS512)
 //! This algorithm is used to sign and verify JSON Web Tokens using the RSASSA-PKCS1-v1_5.
-//! A [rsa::pkcs1v15::SigningKey] signing key is used to provide the underlying signature
-//! algorithm.
+//! Use [rsa::pkcs1v15::SigningKey] to sign tokens, and [rsa::pkcs1v15::VerifyingKey] to verify tokens.
 //!
 //! A key of size 2048 bits or larger MUST be used with these algorithms.
 //!
@@ -14,9 +13,14 @@
 //!
 //! # PSS (PS256, PS384, PS512)
 //! This algorithm is used to sign and verify JSON Web Tokens using the RSASSA-PSS.
+//!
+//! Use [rsa::pss::BlindedSigningKey] to sign tokens, and [rsa::pss::VerifyingKey] to verify tokens.
 
 use base64ct::{Base64UrlUnpadded, Encoding};
 use rsa::PublicKeyParts;
+
+pub use rsa::pkcs1v15;
+pub use rsa::pss;
 
 impl crate::key::JWKeyType for rsa::RsaPublicKey {
     const KEY_TYPE: &'static str = "RSA";

--- a/src/jose/mod.rs
+++ b/src/jose/mod.rs
@@ -170,10 +170,9 @@ impl<H> Header<H, UnsignedHeader> {
     }
 
     /// Construct the JOSE header from the builder and signing key.
-    pub(crate) fn into_signed_header<A>(self, key: &A::Key) -> Header<H, SignedHeader<A::Key>>
+    pub(crate) fn into_signed_header<A>(self, key: &A) -> Header<H, SignedHeader<A>>
     where
-        A: crate::algorithms::SigningAlgorithm,
-        A::Key: Clone,
+        A: crate::algorithms::TokenSigner + crate::key::SerializeJWK + Clone,
     {
         let state = SignedHeader {
             algorithm: A::IDENTIFIER,
@@ -245,9 +244,9 @@ impl<H> Header<H, RenderedHeader> {
     ///
     /// If the key algorithm does not match the header's algorithm.
     #[allow(unused_variables)]
-    pub(crate) fn into_signed_header<A>(self, key: &A::Key) -> Header<H, SignedHeader<A::Key>>
+    pub(crate) fn into_signed_header<A>(self, key: &A) -> Header<H, SignedHeader<A>>
     where
-        A: crate::algorithms::VerifyAlgorithm,
+        A: crate::algorithms::TokenVerifier + crate::key::SerializeJWK,
     {
         if *self.algorithm() != A::IDENTIFIER {
             panic!(

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -816,10 +816,10 @@ mod test_hmac {
 
         let token = Token::compact((), "This is an HMAC'd message");
 
-        // let signed = token.sign(&algorithm).unwrap();
+        let signed = token.sign(&algorithm).unwrap();
 
-        // let verified = signed.unverify().verify(&algorithm).unwrap();
+        let verified = signed.unverify().verify(&algorithm).unwrap();
 
-        // assert_eq!(verified.payload(), Some(&"This is an HMAC'd message"));
+        assert_eq!(verified.payload(), Some(&"This is an HMAC'd message"));
     }
 }

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -17,13 +17,15 @@ use serde::{
     de::{self, DeserializeOwned},
     ser, Deserialize, Serialize,
 };
+use signature::SignatureEncoding;
 
-use crate::algorithms::VerifyAlgorithm;
+use crate::algorithms::TokenVerifier;
 #[cfg(feature = "fmt")]
 use crate::fmt;
+use crate::key::SerializeJWK;
 use crate::{
-    algorithms::{AlgorithmIdentifier, SigningAlgorithm},
-    base64data::{Base64Data, Base64JSON, DecodeError},
+    algorithms::{AlgorithmIdentifier, TokenSigner},
+    base64data::{Base64JSON, Base64Signature, DecodeError},
     jose::{HeaderAccess, HeaderAccessMut, HeaderState},
     Header,
 };
@@ -352,20 +354,16 @@ where
     /// Once the signature is attached, the internal fields are no longer mutable (as that
     /// would invalidate the signature), but they are still recoverable.
     #[allow(clippy::type_complexity)]
-    pub fn sign<A>(
-        self,
-        algorithm: &A,
-    ) -> Result<Token<P, Signed<H, A>, Fmt>, TokenSigningError<A::Error>>
+    pub fn sign<A>(self, algorithm: &A) -> Result<Token<P, Signed<H, A>, Fmt>, TokenSigningError>
     where
-        A: crate::algorithms::SigningAlgorithm,
-        A::Key: Clone,
+        A: crate::algorithms::TokenSigner + SerializeJWK + Clone,
         // A::Signature: Serialize,
     {
-        let header = self.state.header.into_signed_header::<A>(algorithm.key());
+        let header = self.state.header.into_signed_header(algorithm);
         let headers = Base64JSON(&header).serialized_value()?;
         let payload = self.payload.serialized_value()?;
         let signature = algorithm
-            .sign(&headers, &payload)
+            .try_sign_token(&headers, &payload)
             .map_err(TokenSigningError::Signing)?;
         Ok(Token {
             payload: self.payload,
@@ -391,10 +389,9 @@ where
     pub fn verify<A>(
         self,
         algorithm: &A,
-    ) -> Result<Token<P, Verified<H, A>, Fmt>, TokenVerifyingError<A::Error>>
+    ) -> Result<Token<P, Verified<H, A>, Fmt>, TokenVerifyingError>
     where
-        A: crate::algorithms::VerifyAlgorithm,
-        A::Key: Clone,
+        A: crate::algorithms::TokenVerifier + SerializeJWK,
         P: Serialize,
         H: Serialize,
     {
@@ -407,14 +404,14 @@ where
 
         let signature = &self.state.signature;
         let signature = algorithm
-            .verify(
+            .verify_token(
                 &self.state.header.state.raw,
                 &self.state.payload,
                 signature.as_ref(),
             )
             .map_err(TokenVerifyingError::Verify)?;
 
-        let header = self.state.header.into_signed_header::<A>(algorithm.key());
+        let header = self.state.header.into_signed_header::<A>(algorithm);
 
         Ok(Token {
             payload: self.payload,
@@ -440,8 +437,7 @@ where
 impl<P, H, Alg, Fmt> Token<P, Signed<H, Alg>, Fmt>
 where
     Fmt: TokenFormat,
-    Alg: SigningAlgorithm,
-    Alg::Key: Clone,
+    Alg: TokenSigner + SerializeJWK + Clone,
     H: Serialize,
     P: Serialize,
 {
@@ -459,7 +455,7 @@ where
             state: Unverified {
                 payload,
                 header: self.state.header.into_rendered_header(),
-                signature: Base64Data(self.state.signature.as_ref().to_owned().into()),
+                signature: Base64Signature(self.state.signature.to_bytes().as_ref().into()),
             },
             fmt: self.fmt,
         }
@@ -469,7 +465,7 @@ where
 impl<H, Fmt, P, Alg> Token<P, Signed<H, Alg>, Fmt>
 where
     Fmt: TokenFormat,
-    Alg: SigningAlgorithm,
+    Alg: TokenSigner + SerializeJWK,
 {
     /// Get the payload of the token.
     pub fn payload(&self) -> Option<&P> {
@@ -483,8 +479,7 @@ where
 impl<P, H, Alg, Fmt> Token<P, Verified<H, Alg>, Fmt>
 where
     Fmt: TokenFormat,
-    Alg: VerifyAlgorithm,
-    Alg::Key: Clone,
+    Alg: TokenVerifier + SerializeJWK + Clone,
     H: Serialize,
     P: Serialize,
 {
@@ -502,7 +497,7 @@ where
             state: Unverified {
                 payload,
                 header: self.state.header.into_rendered_header(),
-                signature: Base64Data(self.state.signature.as_ref().to_owned().into()),
+                signature: Base64Signature(self.state.signature.to_bytes().as_ref().into()),
             },
             fmt: self.fmt,
         }
@@ -512,7 +507,7 @@ where
 impl<H, Fmt, P, Alg> Token<P, Verified<H, Alg>, Fmt>
 where
     Fmt: TokenFormat,
-    Alg: VerifyAlgorithm,
+    Alg: TokenVerifier + SerializeJWK,
 {
     /// Get the payload of the token.
     pub fn payload(&self) -> Option<&P> {
@@ -535,7 +530,8 @@ where
     fn fmt<W: std::fmt::Write>(&self, f: &mut fmt::IndentWriter<'_, W>) -> std::fmt::Result {
         let header = serde_json::to_value(self.state.header()).unwrap();
         let payload = serde_json::to_value(&self.payload).unwrap();
-        let signature = serde_json::to_value(Base64Data(self.state.signature())).unwrap();
+        let signature =
+            serde_json::to_value(Base64Signature(self.state.signature().clone())).unwrap();
 
         let token = serde_json::json!({
             "header": header,
@@ -579,11 +575,11 @@ where
 
 /// An error which occured while verifying a token.
 #[derive(Debug, thiserror::Error)]
-pub enum TokenVerifyingError<E> {
+pub enum TokenVerifyingError {
     /// The verification failed during the cryptographic process, meaning
     /// that the signature was invalid, or the algorithm was invalid.
     #[error("verifying: {0}")]
-    Verify(E),
+    Verify(signature::Error),
 
     /// An error occured while re-serailizing the header or payload for
     /// signature verification. This indicates that something is probably
@@ -599,11 +595,11 @@ pub enum TokenVerifyingError<E> {
 
 /// An error which occured while verifying a token.
 #[derive(Debug, thiserror::Error)]
-pub enum TokenSigningError<E> {
+pub enum TokenSigningError {
     /// The verification failed during the cryptographic process, meaning
     /// that the signature was invalid, or the algorithm was invalid.
     #[error("signing: {0}")]
-    Signing(E),
+    Signing(signature::Error),
 
     /// An error occured while serailizing the header or payload for
     /// signature computation. This indicates that something is probably
@@ -687,8 +683,8 @@ mod test_rsa {
         claims.registered.issuer = Some("joe".into());
 
         let token = Token::new((), claims, Compact::new());
-        let algorithm: crate::algorithms::rsa::RsaPkcs1v15<Sha256> =
-            crate::algorithms::rsa::RsaPkcs1v15::new_with_prefix(pkey);
+        let algorithm: rsa::pkcs1v15::SigningKey<Sha256> =
+            rsa::pkcs1v15::SigningKey::new_with_prefix(pkey);
         let signed = token.sign(&algorithm).unwrap();
         {
             let hdr = base64ct::Base64UrlUnpadded::encode_string(
@@ -741,7 +737,8 @@ mod test_ecdsa {
     use super::*;
 
     use base64ct::Encoding;
-    use elliptic_curve::{FieldBytes, SecretKey};
+    use ecdsa::SigningKey;
+    use elliptic_curve::FieldBytes;
     use serde_json::json;
     use zeroize::Zeroize;
 
@@ -749,12 +746,12 @@ mod test_ecdsa {
         s.chars().filter(|c| !c.is_whitespace()).collect()
     }
 
-    fn ecdsa(jwk: &serde_json::Value) -> SecretKey<p256::NistP256> {
+    fn ecdsa(jwk: &serde_json::Value) -> SigningKey<p256::NistP256> {
         let d_b64 = strip_whitespace(jwk["d"].as_str().unwrap());
         let mut d_bytes = FieldBytes::<p256::NistP256>::default();
         base64ct::Base64UrlUnpadded::decode(&d_b64, &mut d_bytes).unwrap();
 
-        let key = SecretKey::from_slice(&d_bytes).unwrap();
+        let key = SigningKey::from_slice(&d_bytes).unwrap();
         d_bytes.zeroize();
         key
     }
@@ -775,9 +772,9 @@ mod test_ecdsa {
 
         let signed = token.sign(&key).unwrap();
 
-        let verifying_key: ecdsa::VerifyingKey<_> = key.public_key().into();
+        let verifying_key = key.verifying_key();
 
-        let verified = signed.unverify().verify(&verifying_key).unwrap();
+        let verified = signed.unverify().verify(verifying_key).unwrap();
 
         assert_eq!(verified.payload(), Some(&"This is a signed message"));
     }
@@ -819,10 +816,10 @@ mod test_hmac {
 
         let token = Token::compact((), "This is an HMAC'd message");
 
-        let signed = token.sign(&algorithm).unwrap();
+        // let signed = token.sign(&algorithm).unwrap();
 
-        let verified = signed.unverify().verify(&algorithm).unwrap();
+        // let verified = signed.unverify().verify(&algorithm).unwrap();
 
-        assert_eq!(verified.payload(), Some(&"This is an HMAC'd message"));
+        // assert_eq!(verified.payload(), Some(&"This is an HMAC'd message"));
     }
 }


### PR DESCRIPTION
Change signatures to use underlying traits from RustCrypto, instead of independent traits and implementations.