### PR TITLE
Object safety for JWS key traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha1 = "0.10"
 sha2 = "0.10"
-signature = { version = "2.2", features = ["digest"] }
+signature = { version = "2.2", features = ["digest", "std"] }
 thiserror = "1"
 url = { version = "2.5", features = ["serde"] }
 zeroize = { version = "1.7", features = ["serde", "derive"] }

--- a/src/jose/mod.rs
+++ b/src/jose/mod.rs
@@ -187,7 +187,7 @@ impl<H> Header<H, UnsignedHeader> {
         A: crate::algorithms::TokenSigner + crate::key::SerializeJWK + Clone,
     {
         let state = SignedHeader {
-            algorithm: A::IDENTIFIER,
+            algorithm: key.identifier(),
             key: DerivedKeyValue::derive(self.state.key, key),
             thumbprint: DerivedKeyValue::derive(self.state.thumbprint, key),
             thumbprint_sha256: DerivedKeyValue::derive(self.state.thumbprint_sha256, key),
@@ -260,10 +260,10 @@ impl<H> Header<H, RenderedHeader> {
     where
         A: crate::algorithms::TokenVerifier + crate::key::SerializeJWK,
     {
-        if *self.algorithm() != A::IDENTIFIER {
+        if *self.algorithm() != key.identifier() {
             panic!(
                 "algorithm mismatch: expected header to have {:?}, got {:?}",
-                A::IDENTIFIER,
+                key.identifier(),
                 self.algorithm()
             );
         }

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -467,9 +467,9 @@ where
         P: Serialize,
         H: Serialize,
     {
-        if A::IDENTIFIER != *self.state.header.algorithm() {
+        if algorithm.identifier() != *self.state.header.algorithm() {
             return Err(TokenVerifyingError::Algorithm(
-                A::IDENTIFIER,
+                algorithm.identifier(),
                 *self.state.header.algorithm(),
             ));
         }

--- a/src/token/state.rs
+++ b/src/token/state.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use signature::SignatureEncoding;
 
 use crate::{
-    algorithms::{JoseAlgorithm, SignatureBytes, TokenSigner},
+    algorithms::{DynJoseAlgorithm, SignatureBytes, TokenSigner},
     base64data::Base64Signature,
     jose,
     key::SerializeJWK,
@@ -92,7 +92,7 @@ impl<H> MaybeSigned for Unsigned<H> {
 #[serde(bound(serialize = "H: Serialize, Alg: Clone, Alg::Signature: Serialize",))]
 pub struct Signed<H, Alg>
 where
-    Alg: JoseAlgorithm + SerializeJWK,
+    Alg: DynJoseAlgorithm + SerializeJWK,
 {
     pub(super) header: jose::Header<H, jose::SignedHeader<Alg>>,
     pub(super) signature: Alg::Signature,
@@ -143,7 +143,7 @@ where
 #[serde(bound(serialize = "H: Serialize, Alg: Clone, Alg::Signature: Serialize",))]
 pub struct Verified<H, Alg>
 where
-    Alg: JoseAlgorithm + SerializeJWK,
+    Alg: DynJoseAlgorithm + SerializeJWK,
 {
     pub(super) header: jose::Header<H, jose::SignedHeader<Alg>>,
     pub(super) signature: Alg::Signature,
@@ -151,7 +151,7 @@ where
 
 impl<H, Alg> MaybeSigned for Verified<H, Alg>
 where
-    Alg: JoseAlgorithm + SerializeJWK,
+    Alg: DynJoseAlgorithm + SerializeJWK,
 {
     type HeaderState = jose::SignedHeader<Alg>;
     type Header = H;
@@ -175,7 +175,7 @@ where
 
 impl<H, Alg> HasSignature for Verified<H, Alg>
 where
-    Alg: JoseAlgorithm + SerializeJWK,
+    Alg: DynJoseAlgorithm + SerializeJWK,
 {
     type Signature = Alg::Signature;
 


### PR DESCRIPTION
Ensures that TokenSigner and TokenVerifier are object-safe traits, and
so can be used with <dyn ...>