### PR TITLE
Compatibility for YACME

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ digest = { version = "0.10" }
 ecdsa = { version = "0.16", features = ["signing", "der"], optional = true }
 hmac = { version = "0.12", optional = true }
 p256 = { version = "0.13", features = ["ecdsa", "jwk"], optional = true }
-p384 = { version = "0.13", optional = true }
-p521 = { version = "0.13", optional = true }
+p384 = { version = "0.13", features = ["ecdsa", "jwk"], optional = true }
+p521 = { version = "0.13", features = ["ecdsa", "jwk"], optional = true }
 pkcs8 = "0.10"
 rand_core = { version = "0.6.4", optional = true, default-features = false }
 rsa = { version = "0.9", features = ["sha2"], optional = true }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ecosystem.
 
 This is an example [JWT][], taken from the ACME standard ([RFC 8555][RFC8555]):
 
-```json
+```javascript
 {
   "protected": base64url({
     "alg": "ES256",

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -159,7 +159,7 @@ pub trait JsonWebAlgorithm {
     const IDENTIFIER: AlgorithmIdentifier;
 }
 
-/// A trait to associate an alogritm identifier with an algorithm.
+/// An object-safe trait to associate an alogritm identifier with an algorithm.
 ///
 /// This is a dynamic version of [`JsonWebAlgorithm`], which allows for
 /// dynamic dispatch of the algorithm, and object-safety for the trait.
@@ -434,4 +434,5 @@ mod test {
     // a concrete `Signature` type, or an object-safe trait.
     sa::assert_obj_safe!(TokenSigner<SignatureBytes>);
     sa::assert_obj_safe!(TokenVerifier<SignatureBytes>);
+    sa::assert_obj_safe!(DynJsonWebAlgorithm);
 }

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -189,7 +189,7 @@ pub trait JsonWebAlgorithmDigest: JsonWebAlgorithm {
 /// A trait to represent an algorithm which can sign a JWT.
 ///
 /// This trait should apply to signing keys.
-pub trait TokenSigner<S>: DynJsonWebAlgorithm + SerializePublicJWK
+pub trait TokenSigner<S = SignatureBytes>: DynJsonWebAlgorithm + SerializePublicJWK
 where
     S: SignatureEncoding,
 {
@@ -229,7 +229,8 @@ where
 #[cfg(feature = "rand")]
 /// A trait to represent an algorithm which can sign a JWT, with a source of
 /// randomness.
-pub trait RandomizedTokenSigner<S>: DynJsonWebAlgorithm + SerializePublicJWK
+pub trait RandomizedTokenSigner<S = SignatureBytes>:
+    DynJsonWebAlgorithm + SerializePublicJWK
 where
     S: SignatureEncoding,
 {
@@ -259,7 +260,7 @@ where
 ///
 /// This trait should apply to the equivalent of public keys, which have enough information
 /// to verify a JWT signature, but not necessarily to sing it.
-pub trait TokenVerifier<S>: DynJsonWebAlgorithm
+pub trait TokenVerifier<S = SignatureBytes>: DynJsonWebAlgorithm
 where
     S: SignatureEncoding,
 {

--- a/src/algorithms/mod.rs
+++ b/src/algorithms/mod.rs
@@ -30,6 +30,7 @@
 //! - RS512: RSASSA-PKCS1-v1_5 using SHA-512 via [`rsa::pkcs1v15::SigningKey<Sha512>`][rsa::pkcs1v15::SigningKey] / [`rsa::pkcs1v15::VerifyingKey<Sha512>`][rsa::pkcs1v15::VerifyingKey]
 //! - PS256: RSASSA-PSS using SHA-256 and MGF1 with SHA-256 via [`rsa::pss::SigningKey<Sha256>`][rsa::pss::SigningKey] / [`rsa::pss::VerifyingKey<Sha256>`][rsa::pss::VerifyingKey]
 //! - PS384: RSASSA-PSS using SHA-384 and MGF1 with SHA-384 via [`rsa::pss::SigningKey<Sha384>`][rsa::pss::SigningKey] / [`rsa::pss::VerifyingKey<Sha384>`][rsa::pss::VerifyingKey]
+//! - PS512: RSASSA-PSS using SHA-512 and MGF1 with SHA-384 via [`rsa::pss::SigningKey<Sha512>`][rsa::pss::SigningKey] / [`rsa::pss::VerifyingKey<Sha512>`][rsa::pss::VerifyingKey]
 //!
 //! ## ECDSA
 //!

--- a/src/algorithms/rsa.rs
+++ b/src/algorithms/rsa.rs
@@ -301,6 +301,7 @@ mod test {
     use base64ct::Encoding as _;
     use serde_json::json;
     use sha2::Sha256;
+    use signature::Keypair;
     use signature::SignatureEncoding;
 
     fn strip_whitespace(s: &str) -> String {
@@ -311,39 +312,43 @@ mod test {
         rsa::RsaPrivateKey::from_value(jwk).unwrap()
     }
 
-    #[test]
-    fn rfc7515_example_a2_signature() {
-        let pkey = rsa(json!( {"kty":"RSA",
+    fn jwk() -> serde_json::Value {
+        json!( {"kty":"RSA",
               "n":"ofgWCuLjybRlzo0tZWJjNiuSfb4p4fAkd_wWJcyQoTbji9k0l8W26mPddx
-             HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs
-             D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH
-             SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV
-             MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8
-             NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",
+       HmfHQp-Vaw-4qPCJrcS2mJPMEzP1Pt0Bm4d4QlL-yRT-SFd2lZS-pCgNMs
+       D1W_YpRPEwOWvG6b32690r2jZ47soMZo9wGzjb_7OMg0LOL-bSf63kpaSH
+       SXndS5z5rexMdbBYUsLA9e-KXBdQOS-UTo7WTBEMa2R2CapHg665xsmtdV
+       MTBQY4uDZlxvb3qCo5ZwKh9kG4LT6_I5IhlJH7aGhyxXFvUK-DWNmoudF8
+       NAco9_h9iaGNj8q2ethFkMLs91kzk2PAcDTW9gb54h4FRWyuXpoQ",
               "e":"AQAB",
               "d":"Eq5xpGnNCivDflJsRQBXHx1hdR1k6Ulwe2JZD50LpXyWPEAeP88vLNO97I
-             jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0
-             BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn
-             439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT
-             CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh
-             BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",
+       jlA7_GQ5sLKMgvfTeXZx9SE-7YwVol2NXOoAJe46sui395IW_GO-pWJ1O0
+       BkTGoVEn2bKVRUCgu-GjBVaYLU6f3l9kJfFNS3E0QbVdxzubSu3Mkqzjkn
+       439X0M_V51gfpRLI9JYanrC4D4qAdGcopV_0ZHHzQlBjudU2QvXt4ehNYT
+       CBr6XCLQUShb1juUO1ZdiYoFaFQT5Tw8bGUl_x_jTj3ccPDVZFD9pIuhLh
+       BOneufuBiB4cS98l2SR_RQyGWSeWjnczT0QU91p1DhOVRuOopznQ",
               "p":"4BzEEOtIpmVdVEZNCqS7baC4crd0pqnRH_5IB3jw3bcxGn6QLvnEtfdUdi
-             YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG
-             BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",
+       YrqBdss1l58BQ3KhooKeQTa9AB0Hw_Py5PJdTJNPY8cQn7ouZ2KKDcmnPG
+       BY5t7yLc1QlQ5xHdwW1VhvKn-nXqhJTBgIPgtldC-KDV5z-y2XDwGUc",
               "q":"uQPEfgmVtjL0Uyyx88GZFF1fOunH3-7cepKmtH4pxhtCoHqpWmT8YAmZxa
-             ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA
-             -njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",
+       ewHgHAjLYsp1ZSe7zFYHj7C6ul7TjeLQeZD_YwD66t62wDmpe_HlB-TnBA
+       -njbglfIsRLtXlnDzQkv5dTltRJ11BKBBypeeF6689rjcJIDEz9RWdc",
               "dp":"BwKfV3Akq5_MFZDFZCnW-wzl-CCo83WoZvnLQwCTeDv8uzluRSnm71I3Q
-             CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb
-             34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",
+       CLdhrqE2e9YkxvuxdBfpT_PI7Yz-FOKnu1R6HsJeDCjn12Sk3vmAktV2zb
+       34MCdy7cpdTh_YVr7tss2u6vneTwrA86rZtu5Mbr1C1XsmvkxHQAdYo0",
               "dq":"h_96-mK1R_7glhsum81dZxjTnYynPbZpHziZjeeHcXYsXaaMwkOlODsWa
-             7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky
-             NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",
+       7I9xXDoRwbKgB719rrmI2oKr6N3Do9U0ajaHF-NKJnwgjMd2w9cjz3_-ky
+       NlxAr2v4IKhGNpmM5iIgOS1VZnOZ68m6_pbLBSp3nssTdlqvd0tIiTHU",
               "qi":"IYd7DHOhrWvxkwPQsRM2tOgrjbcrfvtQJipd-DlcxyVuuM9sQLdgjVk2o
-             y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU
-             W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"
+       y26F0EmpScGLq2MowX7fhd_QJQ3ydy5cY7YIBi87w93IKLEdfnbJtoOPLU
+       W0ITrJReOgo1cq9SbsxYawBgfp_gh6A5603k2-ZQwVK0JKSHuLFkuQ3U"
              }
-        ));
+        )
+    }
+
+    #[test]
+    fn rfc7515_example_a2_signature() {
+        let pkey = rsa(jwk());
 
         let payload = strip_whitespace(
             "eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGFt
@@ -370,5 +375,31 @@ mod test {
                 p0igcN_IoypGlUPQGe77Rw"
             )
         );
+    }
+
+    #[test]
+    fn rsa_pkcs1v15_algorithm() {
+        let pkey = rsa(jwk());
+
+        let payload = json! {
+            {
+                "iss": "joe",
+                "exp": 1300819380,
+                "http://example.com/is_root": true
+            }
+        };
+
+        let token = crate::Token::compact((), payload);
+        let algorithm: rsa::pkcs1v15::SigningKey<Sha256> = rsa::pkcs1v15::SigningKey::new(pkey);
+
+        let signed = token
+            .sign::<_, rsa::pkcs1v15::Signature>(&algorithm)
+            .unwrap();
+
+        let unverified = signed.unverify();
+        let verifying_key = algorithm.verifying_key();
+        unverified
+            .verify::<_, rsa::pkcs1v15::Signature>(&verifying_key)
+            .unwrap();
     }
 }

--- a/src/base64data.rs
+++ b/src/base64data.rs
@@ -32,6 +32,112 @@ pub enum DecodeError {
     InvalidData(#[source] Box<dyn std::error::Error + Send + Sync>),
 }
 
+/// Wrapper type for types which implement AsRef<[u8]> to indicate that
+/// they should serialize as bytes with a Base64 URL-safe encoding.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Base64Data<T>(pub T);
+
+impl<T> Base64Data<T>
+where
+    T: AsRef<[u8]>,
+{
+    pub(crate) fn serialized_value(&self) -> Result<String, serde_json::Error> {
+        Ok(base64ct::Base64UrlUnpadded::encode_string(self.0.as_ref()))
+    }
+}
+
+impl<T> std::fmt::Debug for Base64Data<T>
+where
+    T: AsRef<[u8]>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Base64Data")
+            .field(&self.serialized_value().unwrap())
+            .finish()
+    }
+}
+
+impl<T> From<T> for Base64Data<T> {
+    fn from(value: T) -> Self {
+        Base64Data(value)
+    }
+}
+
+impl<T> ser::Serialize for Base64Data<T>
+where
+    T: AsRef<[u8]>,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let target = self
+            .serialized_value()
+            .map_err(|err| unreachable!("serialization error: {}", err))?;
+        serializer.serialize_str(&target)
+    }
+}
+
+impl<T> AsRef<[u8]> for Base64Data<T>
+where
+    T: AsRef<[u8]>,
+{
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
+struct Base64DataVisitor<T>(PhantomData<T>);
+
+impl<'de, T> de::Visitor<'de> for Base64DataVisitor<T>
+where
+    T: for<'a> TryFrom<&'a [u8]>,
+{
+    type Value = Base64Data<T>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("base64url encoded data")
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let data = base64ct::Base64UrlUnpadded::decode_vec(v)
+            .map_err(|_| E::invalid_value(de::Unexpected::Str(v), &"invalid base64url encoding"))?;
+
+        let realized = T::try_from(data.as_ref())
+            .map_err(|_| E::invalid_value(de::Unexpected::Str(v), &"can't parse internal data"))?;
+        Ok(Base64Data(realized))
+    }
+}
+
+impl<'de, T> de::Deserialize<'de> for Base64Data<T>
+where
+    T: for<'a> TryFrom<&'a [u8]>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_str(Base64DataVisitor(PhantomData))
+    }
+}
+
+#[cfg(feature = "fmt")]
+impl<T> fmt::JWTFormat for Base64Data<T>
+where
+    T: AsRef<[u8]>,
+{
+    fn fmt<W: fmt::Write>(&self, f: &mut IndentWriter<'_, W>) -> fmt::Result {
+        write!(
+            f,
+            "b64\"{}\"",
+            base64ct::Base64UrlUnpadded::encode_string(self.0.as_ref())
+        )
+    }
+}
+
 /// Wrapper type to indicate that the inner type should be serialized
 /// as bytes with a Base64 URL-safe encoding.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -101,9 +207,9 @@ where
     }
 }
 
-struct Base64Visitor<T>(PhantomData<T>);
+struct Base64SignatureVisitor<T>(PhantomData<T>);
 
-impl<'de, T> de::Visitor<'de> for Base64Visitor<T>
+impl<'de, T> de::Visitor<'de> for Base64SignatureVisitor<T>
 where
     T: for<'a> TryFrom<&'a [u8]>,
 {
@@ -134,7 +240,7 @@ where
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_str(Base64Visitor(PhantomData))
+        deserializer.deserialize_str(Base64SignatureVisitor(PhantomData))
     }
 }
 
@@ -291,6 +397,15 @@ mod test {
 
     #[test]
     fn test_base64_data() {
+        let data = Base64Data::from(vec![1, 2, 3, 4]);
+        let serialized = serde_json::to_string(&data).unwrap();
+        assert_eq!(serialized, r#""AQIDBA""#);
+        let deserialized: Base64Data<Vec<u8>> = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized, data);
+    }
+
+    #[test]
+    fn test_base64_signature() {
         let data = Base64Signature::from(SignatureBytes::from(vec![1, 2, 3, 4]));
         let serialized = serde_json::to_string(&data).unwrap();
         assert_eq!(serialized, r#""AQIDBA""#);

--- a/src/key.rs
+++ b/src/key.rs
@@ -174,6 +174,14 @@ impl JsonWebKey {
         }
     }
 
+    /// Build a JWK from a public key.
+    pub fn build_public<K: SerializePublicJWK + ?Sized>(key: &K) -> Self {
+        JsonWebKey {
+            key_type: key.key_type().into(),
+            parameters: key.public_parameters().into_iter().collect(),
+        }
+    }
+
     /// Build a JWK from a key.
     pub fn build<K: SerializeJWK + ?Sized>(key: &K) -> Self {
         JsonWebKey {
@@ -342,7 +350,7 @@ where
 
 impl<Digest> std::fmt::Display for Thumbprint<Digest> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.thumbprint)
+        f.write_str(&self.thumbprint)
     }
 }
 
@@ -363,13 +371,12 @@ mod test {
 
     sa::assert_obj_safe!(SerializeJWK);
 
-    #[cfg(all(test, feature = "rsa"))]
+    #[cfg(feature = "rsa")]
     mod rsa {
         use super::super::*;
 
         use serde_json::json;
 
-        #[cfg(feature = "rsa")]
         #[test]
         fn rfc7639_example() {
             let key = rsa::RsaPublicKey::from_value(json!({

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -933,7 +933,7 @@ mod test_ecdsa {
 
 #[cfg(all(test, feature = "hmac"))]
 mod test_hmac {
-    use crate::algorithms::hmac::{Hmac, HmacKey};
+    use crate::algorithms::hmac::{DigestSignature, Hmac, HmacKey};
 
     use super::*;
 
@@ -967,7 +967,7 @@ mod test_hmac {
 
         let token = Token::compact((), "This is an HMAC'd message");
 
-        let signed = token.sign(&algorithm).unwrap();
+        let signed = token.sign::<_, DigestSignature<_>>(&algorithm).unwrap();
 
         let verified = signed.unverify().verify(&algorithm).unwrap();
 

--- a/src/token/state.rs
+++ b/src/token/state.rs
@@ -91,7 +91,7 @@ impl<H> MaybeSigned for Unsigned<H> {
 /// signature is both consistent and valid.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(bound(serialize = "H: Serialize, Sig: Serialize",))]
-pub struct Signed<H, Alg, Sig>
+pub struct Signed<H, Alg, Sig = SignatureBytes>
 where
     Alg: DynJsonWebAlgorithm + ?Sized,
 {
@@ -146,7 +146,7 @@ where
 /// consistent with the signature.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(bound(serialize = "H: Serialize, Sig: Serialize",))]
-pub struct Verified<H, Alg, Sig>
+pub struct Verified<H, Alg, Sig = SignatureBytes>
 where
     Alg: DynJsonWebAlgorithm + ?Sized,
 {


### PR DESCRIPTION
- Base64Data type for generic data to be serialized as base64 (as opposed to signatures)
- Support the bag-of-bytes SignatureBytes for HMAC
- Add proper support with signature randomization for RSA PSS
- Add tests for RSA and ECDSA signature types
- Expose a method to directly build a public JWK from any key.