### PR TITLE
Clean up examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .unwrap();
 
     // We will sign the JWT with the RS256 algorithm: RSA with SHA-256.
-    // RsaPkcs1v15 is really an alias to the digital signature algorithm
-    // implementation in the `rsa` crate, but provided in JAWS to make
-    // it clear which types are compatible with JWTs.
     let alg = rsa::pkcs1v15::SigningKey::<Sha256>::new(key);
 
     // Claims can combine registered and custom fields. The claims object
@@ -150,6 +147,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // but a custom type could be passed if we wanted to have custom header
     // fields.
     let mut token = Token::compact((), claims);
+
     // We can modify the headers freely before signing the JWT. In this case,
     // we provide the `typ` header, which is optional in the JWT spec.
     *token.header_mut().r#type() = Some("JWT".to_string());
@@ -159,7 +157,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     token.header_mut().key().derived();
 
     println!("=== Initial JWT ===");
-
     // Initially the JWT has no defined signature:
     println!("{}", token.formatted());
 
@@ -198,12 +195,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(&key, alg.verifying_key().as_ref());
     println!("=== Verification === ");
-
-    // let alg: rsa::pkcs1v15::VerifyingKey<Sha256> = rsa::pkcs1v15::VerifyingKey::new(key);
     let alg: rsa::pkcs1v15::VerifyingKey<Sha256> = alg.verifying_key();
 
     // We can't access the claims until we verify the token.
-    // let verified = token.verify::<_, rsa::pkcs1v15::Signature>(&alg).unwrap();
     let verified = token
         .verify::<_, jaws::algorithms::SignatureBytes>(&alg)
         .unwrap();

--- a/examples/rfc7515a2.rs
+++ b/examples/rfc7515a2.rs
@@ -44,9 +44,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .unwrap();
 
     // We will sign the JWT with the RS256 algorithm: RSA with SHA-256.
-    // RsaPkcs1v15 is really an alias to the digital signature algorithm
-    // implementation in the `rsa` crate, but provided in JAWS to make
-    // it clear which types are compatible with JWTs.
     let alg = rsa::pkcs1v15::SigningKey::<Sha256>::new(key);
 
     // Claims can combine registered and custom fields. The claims object
@@ -67,6 +64,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // but a custom type could be passed if we wanted to have custom header
     // fields.
     let mut token = Token::compact((), claims);
+
     // We can modify the headers freely before signing the JWT. In this case,
     // we provide the `typ` header, which is optional in the JWT spec.
     *token.header_mut().r#type() = Some("JWT".to_string());
@@ -76,7 +74,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     token.header_mut().key().derived();
 
     println!("=== Initial JWT ===");
-
     // Initially the JWT has no defined signature:
     println!("{}", token.formatted());
 
@@ -115,12 +112,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     assert_eq!(&key, alg.verifying_key().as_ref());
     println!("=== Verification === ");
-
-    // let alg: rsa::pkcs1v15::VerifyingKey<Sha256> = rsa::pkcs1v15::VerifyingKey::new(key);
     let alg: rsa::pkcs1v15::VerifyingKey<Sha256> = alg.verifying_key();
 
     // We can't access the claims until we verify the token.
-    // let verified = token.verify::<_, rsa::pkcs1v15::Signature>(&alg).unwrap();
     let verified = token
         .verify::<_, jaws::algorithms::SignatureBytes>(&alg)
         .unwrap();

--- a/examples/save-key.rs
+++ b/examples/save-key.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use jaws::key::DeserializeJWK as _;
 use rsa::{pkcs1::EncodeRsaPublicKey, pkcs8::EncodePrivateKey};
 use serde_json::json;
@@ -40,14 +38,10 @@ fn main() {
 
     let pemdata = pkey.to_pkcs8_pem(Default::default()).unwrap();
 
-    std::io::BufWriter::new(
-        std::fs::File::create(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/examples/rfc7515a2.pem"
-        ))
-        .unwrap(),
+    std::fs::write(
+        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/rfc7515a2.pem"),
+        pemdata,
     )
-    .write_all(pemdata.as_bytes())
     .unwrap();
 
     let pemdata = pkey
@@ -55,13 +49,9 @@ fn main() {
         .to_pkcs1_pem(Default::default())
         .unwrap();
 
-    std::io::BufWriter::new(
-        std::fs::File::create(concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/examples/rfc7515a2.pub"
-        ))
-        .unwrap(),
+    std::fs::write(
+        concat!(env!("CARGO_MANIFEST_DIR"), "/examples/rfc7515a2.pub"),
+        pemdata,
     )
-    .write_all(pemdata.as_bytes())
     .unwrap();
 }


### PR DESCRIPTION
Removes unnecessary low level std::io work, and cleans up comments, removing redundant parts.