### PR TITLE
Adds .message() method to header

### DIFF
--- a/src/jose/mod.rs
+++ b/src/jose/mod.rs
@@ -336,6 +336,12 @@ where
         map.extend(parameters);
         Ok(map.into())
     }
+
+    /// The JOSE header value, serialized into compact form, used for signing.
+
+    pub(crate) fn message(&self) -> Result<String, serde_json::Error> {
+        Base64JSON(&self).serialized_value()
+    }
 }
 
 #[cfg(feature = "fmt")]

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -433,10 +433,9 @@ where
         S: SignatureEncoding,
     {
         let header = self.state.header.into_signed_header(algorithm)?;
-        let headers = Base64JSON(&header).serialized_value()?;
         let payload = self.payload.serialized_value()?;
         let signature = algorithm
-            .try_sign_token(&headers, &payload)
+            .try_sign_token(&header.message()?, &payload)
             .map_err(TokenSigningError::Signing)?;
         Ok(Token {
             payload: self.payload,
@@ -462,10 +461,9 @@ where
         S: SignatureEncoding,
     {
         let header = self.state.header.into_signed_header(algorithm)?;
-        let headers = Base64JSON(&header).serialized_value()?;
         let payload = self.payload.serialized_value()?;
         let signature = algorithm
-            .try_sign_token(&headers, &payload, rng)
+            .try_sign_token(&header.message()?, &payload, rng)
             .map_err(TokenSigningError::Signing)?;
         Ok(Token {
             payload: self.payload,


### PR DESCRIPTION
This provides a single interface for the rendered version of a header suitable for signing. Previously, this was implemented by hand in .sign() and .sign_randomized()