### PR TITLE
Add header protection and custom header transitions

### DIFF
--- a/src/jose/mod.rs
+++ b/src/jose/mod.rs
@@ -181,6 +181,24 @@ impl<H> Header<H, UnsignedHeader> {
         }
     }
 
+    /// Replace the custom header with a new value, preserving other values.
+    pub(crate) fn with_custom_header<H2>(self, custom: H2) -> Header<H2, UnsignedHeader> {
+        Header {
+            state: self.state,
+            registered: self.registered,
+            custom,
+        }
+    }
+
+    /// Reset all the non-custom header values to their defaults.
+    pub(crate) fn clear_registered_header(self) -> Header<H, UnsignedHeader> {
+        Header {
+            state: Default::default(),
+            registered: Default::default(),
+            custom: self.custom,
+        }
+    }
+
     /// Construct the JOSE header from the builder and signing key.
     pub(crate) fn into_signed_header<A>(
         self,
@@ -543,6 +561,12 @@ impl<'h, H, State> HeaderAccessMut<'h, H, State> {
 }
 
 impl<'h, H> HeaderAccessMut<'h, H, UnsignedHeader> {
+    /// Reset all the non-custom header values to their defaults.
+    pub fn reset_registered_headers(&mut self) {
+        self.header.registered = Default::default();
+        self.header.state = Default::default();
+    }
+
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/jose/json_web_key.md"))]
     pub fn key(&mut self) -> &mut DeriveFromKey<JsonWebKey> {
         &mut self.header.state.key

--- a/src/jose/mod.rs
+++ b/src/jose/mod.rs
@@ -135,6 +135,10 @@ pub struct Header<H, State> {
     pub custom: H,
 }
 
+// The access pattern used here is to unify the registered, state and custom fields
+// so that they appear to be a single struct. Different header states store some fields
+// differently (e.g. Algorithm, derived fields), but we want to present a single
+// unified type for access and manipulation.
 impl<H, State> Header<H, State> {
     /// Access fields on the header
     pub fn access(&self) -> HeaderAccess<'_, H, State> {
@@ -187,15 +191,6 @@ impl<H> Header<H, UnsignedHeader> {
             state: self.state,
             registered: self.registered,
             custom,
-        }
-    }
-
-    /// Reset all the non-custom header values to their defaults.
-    pub(crate) fn clear_registered_header(self) -> Header<H, UnsignedHeader> {
-        Header {
-            state: Default::default(),
-            registered: Default::default(),
-            custom: self.custom,
         }
     }
 
@@ -579,50 +574,6 @@ impl<'h, H> HeaderAccessMut<'h, H, UnsignedHeader> {
 
     #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/jose/thumbprint_sha256.md"))]
     pub fn thumbprint_sha256(&mut self) -> &mut DeriveFromKey<Thumbprint<Sha256>> {
-        &mut self.header.state.thumbprint_sha256
-    }
-}
-
-impl<'h, H> HeaderAccessMut<'h, H, SignedHeader> {
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/jose/algorithm.md"))]
-    pub fn algorithm(&self) -> &AlgorithmIdentifier {
-        self.header.algorithm()
-    }
-
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/jose/json_web_key.md"))]
-    pub fn key(&self) -> Option<&JsonWebKey> {
-        self.header.state.json_web_key.as_ref()
-    }
-
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/jose/thumbprint.md"))]
-    pub fn thumbprint(&self) -> Option<&Thumbprint<Sha1>> {
-        self.header.state.thumbprint.as_ref()
-    }
-
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/jose/thumbprint_sha256.md"))]
-    pub fn thumbprint_sha256(&self) -> Option<&Thumbprint<Sha256>> {
-        self.header.state.thumbprint_sha256.as_ref()
-    }
-}
-
-impl<'h, H> HeaderAccessMut<'h, H, RenderedHeader> {
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/jose/algorithm.md"))]
-    pub fn algorithm(&mut self) -> &mut AlgorithmIdentifier {
-        &mut self.header.state.algorithm
-    }
-
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/jose/json_web_key.md"))]
-    pub fn key(&mut self) -> &mut Option<JsonWebKey> {
-        &mut self.header.state.key
-    }
-
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/jose/thumbprint.md"))]
-    pub fn thumbprint(&mut self) -> &mut Option<Thumbprint<Sha1>> {
-        &mut self.header.state.thumbprint
-    }
-
-    #[doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/jose/thumbprint_sha256.md"))]
-    pub fn thumbprint_sha256(&mut self) -> &mut Option<Thumbprint<Sha256>> {
         &mut self.header.state.thumbprint_sha256
     }
 }

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -760,7 +760,7 @@ pub enum TokenVerifyingError {
     /// The verification failed during the cryptographic process, meaning
     /// that the signature was invalid, or the algorithm was invalid.
     #[error("verifying: {0}")]
-    Verify(signature::Error),
+    Verify(#[source] signature::Error),
 
     /// An error occured while re-serailizing the header or payload for
     /// signature verification. This indicates that something is probably

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -294,6 +294,33 @@ where
     }
 }
 
+impl<P, Fmt> Token<P, Unsigned<()>, Fmt>
+where
+    Fmt: TokenFormat,
+{
+    /// Create an empty token with no custom header values.
+    pub fn blank(fmt: Fmt) -> Self {
+        Token {
+            payload: Payload::Empty,
+            state: Unsigned {
+                header: Header::new(()),
+            },
+            fmt,
+        }
+    }
+
+    /// Create a token with a given payload and format, but no custom header values.
+    pub fn new_with_payload(payload: P, fmt: Fmt) -> Self {
+        Token {
+            payload: Payload::Json(payload.into()),
+            state: Unsigned {
+                header: Header::new(()),
+            },
+            fmt,
+        }
+    }
+}
+
 impl<P, H> Token<P, Unsigned<H>, Compact> {
     /// Create a new token with the given header and payload, in the compact format.
     ///
@@ -410,6 +437,17 @@ where
         match &self.payload {
             Payload::Json(data) => Some(data.as_ref()),
             Payload::Empty => None,
+        }
+    }
+
+    /// Replace the custom header fields of the token.
+    pub fn with_custom_header<H2>(self, header: H2) -> Token<P, Unsigned<H2>, Fmt> {
+        Token {
+            payload: self.payload,
+            state: Unsigned {
+                header: self.state.header.with_custom_header(header),
+            },
+            fmt: self.fmt,
         }
     }
 }

--- a/src/token/mod.rs
+++ b/src/token/mod.rs
@@ -265,35 +265,6 @@ pub struct Token<P, State: MaybeSigned = Unsigned<()>, Fmt: TokenFormat = Compac
     fmt: Fmt,
 }
 
-impl<P, State: MaybeSigned, Fmt: TokenFormat> Token<P, State, Fmt> {
-    /// Access to Token header values.
-    ///
-    /// All access is read-only, and the header cannot be modified here,
-    /// see [`Token::header_mut`] for mutable access.
-    ///
-    /// Header fields are accessed as methods on [`HeaderAccess`], and
-    /// their types will depend on the state of the token. Additionally,
-    /// the `alg` field will not be availalbe for unsigned token types.
-    ///
-    /// # Example: No custom headers, only registered headers.
-    ///
-    /// ```
-    /// use jaws::token::Token;
-    ///
-    /// let token = Token::compact((), ());
-    /// let header = token.header();
-    /// assert_eq!(&header.r#type(), &None);
-    /// ```
-    pub fn header(&self) -> HeaderAccess<'_, State::Header, State::HeaderState> {
-        HeaderAccess::new(self.state.header())
-    }
-
-    /// Mutable access to Token header values
-    pub fn header_mut(&mut self) -> HeaderAccessMut<State::Header, State::HeaderState> {
-        HeaderAccessMut::new(self.state.header_mut())
-    }
-}
-
 impl<P, H, Fmt> Token<P, Unsigned<H>, Fmt>
 where
     Fmt: TokenFormat,
@@ -346,6 +317,37 @@ impl<P, H> Token<P, Unsigned<H>, Flat> {
     /// headers, which are not signed and cannot be verified.
     pub fn flat(header: H, payload: P) -> Token<P, Unsigned<H>, Flat> {
         Token::new(header, payload, Flat)
+    }
+}
+
+impl<P, State: MaybeSigned, Fmt: TokenFormat> Token<P, State, Fmt> {
+    /// Access to Token header values.
+    ///
+    /// All access is read-only, and the header cannot be modified here,
+    /// see [`Token::header_mut`] for mutable access.
+    ///
+    /// Header fields are accessed as methods on [`HeaderAccess`], and
+    /// their types will depend on the state of the token. Additionally,
+    /// the `alg` field will not be availalbe for unsigned token types.
+    ///
+    /// # Example: No custom headers, only registered headers.
+    ///
+    /// ```
+    /// use jaws::token::Token;
+    ///
+    /// let token = Token::compact((), ());
+    /// let header = token.header();
+    /// assert_eq!(&header.r#type(), &None);
+    /// ```
+    pub fn header(&self) -> HeaderAccess<'_, State::Header, State::HeaderState> {
+        HeaderAccess::new(self.state.header())
+    }
+}
+
+impl<P, H, Fmt: TokenFormat> Token<P, Unsigned<H>, Fmt> {
+    /// Mutable access to Token header values
+    pub fn header_mut(&mut self) -> HeaderAccessMut<H, crate::jose::UnsignedHeader> {
+        HeaderAccessMut::new(self.state.header_mut())
     }
 }
 


### PR DESCRIPTION
This pull request includes changes to protect header modification for signed headers and adds improved constructors and custom header transitions for Token. It also sets the source for TokenVerifyingError signature::Error and removes some header access patterns.