### PR TITLE
Turn off default features of chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default-target = "x86_64-unknown-linux-gnu"
 [dependencies]
 base64ct = { version = "1.6", features = ["std"] }
 bytes = { version = "1.6" }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"], default-features = false }
 der = { version = "0.7.9", optional = true }
 digest = { version = "0.10" }
 ecdsa = { version = "0.16", features = ["signing", "der"], optional = true }


### PR DESCRIPTION
This reduces dependencies, specifically wasm-bindgen, and eliminates possible conflicts on non-browser WASM platforms.